### PR TITLE
Fix TypeScript definitions for TS 4.5 nodenext mode

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -10,7 +10,7 @@
 
 import { EventEmitter } from 'events';
 
-export default Nedb;
+export = Nedb;
 
 declare class Nedb<G = any> extends EventEmitter {
   constructor(pathOrOptions?: string | Nedb.DataStoreOptions);


### PR DESCRIPTION
The previous definition only worked because of an optional compatibility layer that makes CommonJS look like native ESM.

- [Reference of DefinitelyTyped version](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/nedb/index.d.ts#L13)
- [Sandbox with workaround installed](https://codesandbox.io/s/ts-http-nedb-flex-uu7sm?file=/ts-esm-compat.sh).

## Workaround 

```
sed -i '13s/export default Nedb/export = Nedb/' ./node_modules/@seald-io/nedb/index.d.ts
```