### PR TITLE
storage.js: check fsync capability from return code rather than using process.platform heuristics

### DIFF
--- a/lib/storage.js
+++ b/lib/storage.js
@@ -50,15 +50,25 @@ storage.flushToStorage = (options, callback) => {
     flags = options.isDir ? 'r' : 'r+'
   }
 
-  // Windows can't fsync (FlushFileBuffers) directories. We can live with this as it cannot cause 100% dataloss
-  // except in the very rare event of the first time database is loaded and a crash happens
-  if (flags === 'r' && (process.platform === 'win32' || process.platform === 'win64')) return callback(null)
+  /**
+   * Some OSes and/or storage backends (augmented node fs) do not support fsync (FlushFileBuffers) directories,
+   * or calling open() on directories at all. Flushing fails silently in this case, supported by following heuristics:
+   *  + isDir === true
+   *  |-- open(<dir>) -> (err.code === 'EISDIR'): can't call open() on directories (eg. BrowserFS)
+   *  `-- fsync(<dir>) -> (errFS.code === 'EPERM' || errFS.code === 'EISDIR'): can't fsync directory: permissions are checked
+   *        on open(); EPERM error should only occur on fsync incapability and not for general lack of permissions (e.g. Windows)
+   *
+   * We can live with this as it cannot cause 100% dataloss except in the very rare event of the first time
+   * database is loaded and a crash happens.
+   */
 
   fs.open(filename, flags, (err, fd) => {
-    if (err) return callback(err)
+    if (err) {
+      return callback((err.code === 'EISDIR' && options.isDir) ? null : err)
+    }
     fs.fsync(fd, errFS => {
       fs.close(fd, errC => {
-        if (errFS || errC) {
+        if ((errFS || errC) && !((errFS.code === 'EPERM' || errFS.code === 'EISDIR') && options.isDir)) {
           const e = new Error('Failed to flush to storage')
           e.errorOnFsync = errFS
           e.errorOnClose = errC

--- a/test/byline.test.js
+++ b/test/byline.test.js
@@ -37,7 +37,7 @@ describe('byline', function () {
     lineStream.pipe(output)
     output.on('close', function () {
       const out = fs.readFileSync(localPath('test.txt'), 'utf8')
-      const in_ = fs.readFileSync(localPath('empty.txt'), 'utf8').replace(/\n/g, '')
+      const in_ = fs.readFileSync(localPath('empty.txt'), 'utf8').replace(/\r?\n/g, '')
       assert.equal(in_, out)
       fs.unlinkSync(localPath('test.txt'))
       done()

--- a/test_lac/openFdsLaunch.sh
+++ b/test_lac/openFdsLaunch.sh
@@ -1,2 +1,3 @@
+#!/bin/sh
 ulimit -n 128
 node ./test_lac/openFds.test.js


### PR DESCRIPTION
*This pull request was originally filed against [JamesMGreene/nestdb](https://github.com/JamesMGreene/nestdb/pull/48)*

**Why:**
Currently fsync on the directory containing the database is skipped if `process.platform` equals `win32` or `win64`. This check is considered insufficient and should be replaced by checks evaluating the error responses of operations, as there exists more than the default Linux (and possibly assumed posix compatible) and Windows filesystem backend/driver/adapter implementations.

An Example for (multiple) implementations of filesystem backends is [BrowserFS](https://github.com/jvilk/BrowserFS/), where most filesystems are not backed by physical storage and thus do neither use the OSs' implementation, nor libuvs' wrappers (as it may be ran in some browser). In this example, using nestdbs' **node variant** in the browser, with default webpack polyfills and BrowserFS as a node `fs` compatible filesystem adapter implementation, is completely possible, but chokes because of the *is windows*-check for determining fsync directory capability.

Testing for the actual error responses of filesystem operations allows to silently ignore the incapability, based on the actual implementations' capabilities.

**What is being changed:**
*No API changes. No observable behavior changes with default node `fs` module.*

Changing the original behavior of branching out of `flushToStorage()`
```js
// original
if (flags === 'r' && (process.platform === 'win32' || process.platform === 'win64')) { return callback(null); }
  fs.open(filename, flags, function (err, fd) {
    // ...
  });
```
... to checks of the fs operation return codes.

When calling `open()` on a directory yields an `EISDIR` error, we can safely assume no fsync dir support. Access permissions  and rights for the current user should be checked on `open()` and yield an `EPERM` error if not sufficient. An `EPERM` error should thus never be returned for a call to `fsync()` on fsync dir capable implementations, as permissions have already been checked. It is thus assumed, that a `EPERM` (returned on Windows) or `EISDIR` error safely indicates a fsync dir incapability and not a permission error.
```js
// new
  fs.open(filename, flags, function (err, fd) {
    if (err) {
      return callback((err.code === 'EISDIR' && options.isDir) ? null : err);
    }
    fs.fsync(fd, function (errFS) {
      fs.close(fd, function (errC) {
        if ((errFS || errC) && !((errFS.code === 'EPERM' || errFS.code === 'EISDIR') && options.isDir)) {
          // ...
        } else {
          return callback(null);
        }
      });
    });
  });
```

- All tests passing on *Windows 10*, *Alpine v3.11* and *Debian Buster*.
- No observable differences in behavior (types and locations of thrown errors) to original implementation found, when dropping write permission for database file or directory (regarding the check for `EPERM` as indicator) (platforms as above)
- make `byline` test run with windows line endings to validate storage behavior on windows
- add shebang in EMFILE exhaustion test script
---

 - [ ] ~~Add or update tests, if applicable~~
 - [x] Update code comments, if applicable
 - [ ] ~~Update documentation, if applicable~~
