### PR TITLE
Add require Buffer to allow for Buffer.isBuffer()

### DIFF
--- a/lib/byline.js
+++ b/lib/byline.js
@@ -25,6 +25,7 @@
  */
 const stream = require('stream')
 const timers = require('timers')
+const Buffer = require('buffer').Buffer;
 
 const createLineStream = (readStream, options) => {
   if (!readStream) throw new Error('expected readStream')


### PR DESCRIPTION
Adding const Buffer = require('buffer').Buffer; to allow the Buffer.isBuffer() function to work properly. See issue #33. 