### PR TITLE
Fix stack overflow

### DIFF
--- a/lib/datastore.js
+++ b/lib/datastore.js
@@ -668,7 +668,7 @@ class Datastore extends EventEmitter {
    * @private
    */
   async _getCandidatesAsync (query, dontExpireStaleDocs = false) {
-    const validDocs = []
+    let validDocs = []
 
     // STEP 1: get candidates list by checking indexes from most to least frequent usecase
     const docs = this._getRawCandidates(query)
@@ -684,7 +684,7 @@ class Datastore extends EventEmitter {
       for (const _id of expiredDocsIds) {
         await this._removeAsync({ _id }, {})
       }
-    } else validDocs.push(...docs)
+    } else validDocs = docs
     return validDocs
   }
 


### PR DESCRIPTION
This replaces a spread call `validDocs.push(...docs)` where `validDocs` was empty with simple assignment `validDocs = docs` to avoid a stack overflow with a big `docs` array.

```
RangeError: Maximum call stack size exceeded
```

Spread calls use stack space, so `foo.push(...REALLY_BIG_ARRAY)` uses LOTS of stack space and it can easily cause a stack overflow.