### PR TITLE
typescript namespace and class name collision avoidance

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -12,144 +12,144 @@
 
 import { EventEmitter } from "events";
 
-export default Nedb;
+export default Nedb.DataStore;
 
-export type Document<Schema> = Schema & {
-  _id: string;
-};
+export namespace Nedb {
+  export type Document<Schema> = Schema & {
+    _id: string;
+  };
+  
+  export class DataStore<Schema = Record<string, any>> extends EventEmitter {
+    constructor(pathOrOptions?: string | Nedb.DataStoreOptions);
+  
+    persistence: Nedb.Persistence;
+  
+    autoloadPromise: Promise<void> | null;
+  
+    loadDatabase(callback?: (err: Error | null) => void): void;
+  
+    loadDatabaseAsync(): Promise<void>;
+  
+    dropDatabase(callback?: (err: Error | null) => void): void;
+  
+    dropDatabaseAsync(): Promise<void>;
+  
+    compactDatafile(callback?: (err: Error | null) => void): void;
+  
+    compactDatafileAsync(): Promise<void>;
+  
+    setAutocompactionInterval(interval: number): void;
+  
+    stopAutocompaction(): void;
+  
+    getAllData<T extends Schema>(): Document<T>[];
+  
+    ensureIndex(
+      options: Nedb.EnsureIndexOptions,
+      callback?: (err: Error | null) => void
+    ): void;
+  
+    ensureIndexAsync(options: Nedb.EnsureIndexOptions): Promise<void>;
+  
+    removeIndex(fieldName: string | string[], callback?: (err: Error | null) => void): void;
+  
+    removeIndexAsync(fieldName: string | string[]): Promise<void>;
+  
+    insert<T extends Schema>(
+      newDoc: T,
+      callback?: (err: Error | null, document: Document<T>) => void
+    ): void;
+    insert<T extends Schema>(
+      newDocs: T[],
+      callback?: (err: Error | null, documents: Document<T>[]) => void
+    ): void;
+  
+    insertAsync<T extends Schema>(newDoc: T): Promise<Document<T>>;
+    insertAsync<T extends Schema>(newDocs: T[]): Promise<Document<T>[]>;
+  
+    count(query: any, callback: (err: Error | null, n: number) => void): void;
+    count(query: any): Nedb.CursorCount;
+  
+    countAsync(query: any): Nedb.Cursor<number>;
+  
+    find<T extends Schema>(
+      query: any,
+      projection: any,
+      callback?: (err: Error | null, documents: Document<T>[]) => void
+    ): void;
+    find<T extends Schema>(
+      query: any,
+      projection?: any
+    ): Nedb.Cursor<T>;
+    find<T extends Schema>(
+      query: any,
+      callback: (err: Error | null, documents: Document<T>[]) => void
+    ): void;
+  
+    findAsync<T extends Schema>(
+      query: any,
+      projection?: any
+    ): Nedb.Cursor<T[]>;
+  
+    findOne<T extends Schema>(
+      query: any,
+      projection: any,
+      callback: (err: Error | null, document: Document<T>) => void
+    ): void;
+    findOne<T extends Schema>(
+      query: any,
+      callback: (err: Error | null, document: Document<T>) => void
+    ): void;
+  
+    findOneAsync<T extends Schema>(
+      query: any,
+      projection?: any
+    ): Nedb.Cursor<T>;
+  
+    update<T extends Schema, O extends Nedb.UpdateOptions>(
+      query: any,
+      updateQuery: any,
+      options?: O,
+      callback?: (
+        err: Error | null,
+        numberOfUpdated: number,
+        affectedDocuments: O['returnUpdatedDocs'] extends true ? O['multi'] extends true ? Document<T>[] | null : Document<T> | null : null,
+        upsert: boolean | null
+      ) => void
+    ): void;
+  
+    updateAsync<T extends Schema, O extends Nedb.UpdateOptions>(
+      query: any,
+      updateQuery: any,
+      options?: O
+    ): Promise<{
+      numAffected: number;
+      affectedDocuments: O['returnUpdatedDocs'] extends true ? O['multi'] extends true ? Document<T>[] | null : Document<T> | null : null;
+      upsert: boolean;
+    }>;
+  
+    remove(
+      query: any,
+      options: Nedb.RemoveOptions,
+      callback?: (err: Error | null, n: number) => void
+    ): void;
+    remove(query: any, callback?: (err: Error | null, n: number) => void): void;
+  
+    removeAsync(query: any, options: Nedb.RemoveOptions): Promise<number>;
+  
+    addListener(event: "compaction.done", listener: () => void): this;
+    on(event: "compaction.done", listener: () => void): this;
+    once(event: "compaction.done", listener: () => void): this;
+    prependListener(event: "compaction.done", listener: () => void): this;
+    prependOnceListener(event: "compaction.done", listener: () => void): this;
+    removeListener(event: "compaction.done", listener: () => void): this;
+    off(event: "compaction.done", listener: () => void): this;
+    listeners(event: "compaction.done"): Array<() => void>;
+    rawListeners(event: "compaction.done"): Array<() => void>;
+    listenerCount(type: "compaction.done"): number;
+  }
 
-declare class Nedb<Schema = Record<string, any>> extends EventEmitter {
-  constructor(pathOrOptions?: string | Nedb.DataStoreOptions);
-
-  persistence: Nedb.Persistence;
-
-  autoloadPromise: Promise<void> | null;
-
-  loadDatabase(callback?: (err: Error | null) => void): void;
-
-  loadDatabaseAsync(): Promise<void>;
-
-  dropDatabase(callback?: (err: Error | null) => void): void;
-
-  dropDatabaseAsync(): Promise<void>;
-
-  compactDatafile(callback?: (err: Error | null) => void): void;
-
-  compactDatafileAsync(): Promise<void>;
-
-  setAutocompactionInterval(interval: number): void;
-
-  stopAutocompaction(): void;
-
-  getAllData<T extends Schema>(): Document<T>[];
-
-  ensureIndex(
-    options: Nedb.EnsureIndexOptions,
-    callback?: (err: Error | null) => void
-  ): void;
-
-  ensureIndexAsync(options: Nedb.EnsureIndexOptions): Promise<void>;
-
-  removeIndex(fieldName: string | string[], callback?: (err: Error | null) => void): void;
-
-  removeIndexAsync(fieldName: string | string[]): Promise<void>;
-
-  insert<T extends Schema>(
-    newDoc: T,
-    callback?: (err: Error | null, document: Document<T>) => void
-  ): void;
-  insert<T extends Schema>(
-    newDocs: T[],
-    callback?: (err: Error | null, documents: Document<T>[]) => void
-  ): void;
-
-  insertAsync<T extends Schema>(newDoc: T): Promise<Document<T>>;
-  insertAsync<T extends Schema>(newDocs: T[]): Promise<Document<T>[]>;
-
-  count(query: any, callback: (err: Error | null, n: number) => void): void;
-  count(query: any): Nedb.CursorCount;
-
-  countAsync(query: any): Nedb.Cursor<number>;
-
-  find<T extends Schema>(
-    query: any,
-    projection: any,
-    callback?: (err: Error | null, documents: Document<T>[]) => void
-  ): void;
-  find<T extends Schema>(
-    query: any,
-    projection?: any
-  ): Nedb.Cursor<T>;
-  find<T extends Schema>(
-    query: any,
-    callback: (err: Error | null, documents: Document<T>[]) => void
-  ): void;
-
-  findAsync<T extends Schema>(
-    query: any,
-    projection?: any
-  ): Nedb.Cursor<T[]>;
-
-  findOne<T extends Schema>(
-    query: any,
-    projection: any,
-    callback: (err: Error | null, document: Document<T>) => void
-  ): void;
-  findOne<T extends Schema>(
-    query: any,
-    callback: (err: Error | null, document: Document<T>) => void
-  ): void;
-
-  findOneAsync<T extends Schema>(
-    query: any,
-    projection?: any
-  ): Nedb.Cursor<T>;
-
-  update<T extends Schema, O extends Nedb.UpdateOptions>(
-    query: any,
-    updateQuery: any,
-    options?: O,
-    callback?: (
-      err: Error | null,
-      numberOfUpdated: number,
-      affectedDocuments: O['returnUpdatedDocs'] extends true ? O['multi'] extends true ? Document<T>[] | null : Document<T> | null : null,
-      upsert: boolean | null
-    ) => void
-  ): void;
-
-  updateAsync<T extends Schema, O extends Nedb.UpdateOptions>(
-    query: any,
-    updateQuery: any,
-    options?: O
-  ): Promise<{
-    numAffected: number;
-    affectedDocuments: O['returnUpdatedDocs'] extends true ? O['multi'] extends true ? Document<T>[] | null : Document<T> | null : null;
-    upsert: boolean;
-  }>;
-
-  remove(
-    query: any,
-    options: Nedb.RemoveOptions,
-    callback?: (err: Error | null, n: number) => void
-  ): void;
-  remove(query: any, callback?: (err: Error | null, n: number) => void): void;
-
-  removeAsync(query: any, options: Nedb.RemoveOptions): Promise<number>;
-
-  addListener(event: "compaction.done", listener: () => void): this;
-  on(event: "compaction.done", listener: () => void): this;
-  once(event: "compaction.done", listener: () => void): this;
-  prependListener(event: "compaction.done", listener: () => void): this;
-  prependOnceListener(event: "compaction.done", listener: () => void): this;
-  removeListener(event: "compaction.done", listener: () => void): this;
-  off(event: "compaction.done", listener: () => void): this;
-  listeners(event: "compaction.done"): Array<() => void>;
-  rawListeners(event: "compaction.done"): Array<() => void>;
-  listenerCount(type: "compaction.done"): number;
-}
-
-declare namespace Nedb {
-  interface Cursor<T> extends Promise<Document<T>> {
+  export interface Cursor<T> extends Promise<Document<T>> {
     sort(query: any): Cursor<T>;
     skip(n: number): Cursor<T>;
     limit(n: number): Cursor<T>;
@@ -158,11 +158,11 @@ declare namespace Nedb {
     execAsync(): Promise<Document<T>>;
   }
 
-  interface CursorCount {
+  export interface CursorCount {
     exec(callback: (err: Error | null, count: number) => void): void;
   }
 
-  interface DataStoreOptions {
+  export interface DataStoreOptions {
     filename?: string;
     timestampData?: boolean;
     inMemoryOnly?: boolean;
@@ -176,24 +176,24 @@ declare namespace Nedb {
     testSerializationHooks?: boolean;
   }
 
-  interface UpdateOptions {
+  export interface UpdateOptions {
     multi?: boolean;
     upsert?: boolean;
     returnUpdatedDocs?: boolean;
   }
 
-  interface RemoveOptions {
+  export interface RemoveOptions {
     multi?: boolean;
   }
 
-  interface EnsureIndexOptions {
+  export interface EnsureIndexOptions {
     fieldName: string | string[];
     unique?: boolean;
     sparse?: boolean;
     expireAfterSeconds?: number;
   }
 
-  interface Persistence {
+  export interface Persistence {
     /** @deprecated */
     compactDatafile(): void;
     /** @deprecated */

--- a/typings-tests.ts
+++ b/typings-tests.ts
@@ -3,34 +3,34 @@
  * Modified my arantes555 on 19.10.2021.
  */
 
-import Datastore from './'
+import DataStore, { Nedb } from './'
 import { mkdirSync } from 'fs'
 
 mkdirSync('./workspace/typings/', { recursive: true })
 process.chdir('./workspace/typings/')
 
 // Type 1: In-memory only datastore (no need to load the database)
-let db = new Datastore()
+let db = new DataStore()
 
 // Type 2: Persistent datastore with manual loading
-db = new Datastore({ filename: 'path/to/datafile' })
+db = new DataStore({ filename: 'path/to/datafile' })
 db.loadDatabase()
 
 // Type 2 bis: Persistent datastore with manual loading with a callback
-db = new Datastore({ filename: 'path/to/datafile' })
+db = new DataStore({ filename: 'path/to/datafile' })
 db.loadDatabase((err: Error | null) => {
   // should not fail
 })
 
 // Type 3: Persistent datastore with automatic loading
-db = new Datastore({ filename: 'path/to/datafile_2', autoload: true, modes: {fileMode: 0o644, dirMode: 0o755} })
+db = new DataStore({ filename: 'path/to/datafile_2', autoload: true, modes: {fileMode: 0o644, dirMode: 0o755} })
 // You can issue commands right away
 
 // Of course you can create multiple datastores if you need several
 // collections. In this case it's usually a good idea to use autoload for all collections.
 const dbContainer: any = {}
-dbContainer.users = new Datastore('path/to/users.db')
-dbContainer.robots = new Datastore('path/to/robots.db')
+dbContainer.users = new DataStore('path/to/users.db')
+dbContainer.robots = new DataStore('path/to/robots.db')
 
 // You need to load each database (here we do it asynchronously)
 dbContainer.users.loadDatabase()
@@ -399,7 +399,7 @@ db.rawListeners('compaction.done') // $ExpectType (() => void)[]
 db.listenerCount('compaction.done') // $ExpectType number
 
 // Test Generics and types
-const db2 = new Datastore<Schema>({ filename: 'path/to/datafile' })
+const db2 = new DataStore<Schema>({ filename: 'path/to/datafile' })
 db2.loadDatabase();
 
 db2.findOne({ _id: 'id1' }, (err, doc) => {
@@ -408,3 +408,9 @@ db2.findOne({ _id: 'id1' }, (err, doc) => {
   // @ts-expect-error
   doc.notExistingKey; // should fail
 });
+
+// namespace checking
+const db3 = new Nedb.DataStore<Schema>({ filename: 'path/to/datafile' })
+let theCursor: Nedb.Cursor<any>;
+let theDoc: Nedb.Document<any>;
+let theOptions: Nedb.DataStoreOptions;


### PR DESCRIPTION
default export still works as expected. all types can be accessed through the Nedb namespace export, including Nedb.DataStore which is the same as the default export.