### PR TITLE
Types: findOne(Async): found document may be null

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -93,17 +93,17 @@ declare class Nedb<Schema = Record<string, any>> extends EventEmitter {
   findOne<T extends Schema>(
     query: any,
     projection: any,
-    callback: (err: Error | null, document: Document<T>) => void
+    callback: (err: Error | null, document: Document<T> | null) => void
   ): void;
   findOne<T extends Schema>(
     query: any,
-    callback: (err: Error | null, document: Document<T>) => void
+    callback: (err: Error | null, document: Document<T> | null) => void
   ): void;
 
   findOneAsync<T extends Schema>(
     query: any,
     projection?: any
-  ): Nedb.Cursor<T>;
+  ): Nedb.Cursor<T | null, Document<T> | null>;
 
   update<T extends Schema, O extends Nedb.UpdateOptions>(
     query: any,
@@ -149,13 +149,13 @@ declare class Nedb<Schema = Record<string, any>> extends EventEmitter {
 }
 
 declare namespace Nedb {
-  interface Cursor<T> extends Promise<Document<T>> {
+  interface Cursor<T, Result = Document<T>> extends Promise<Result> {
     sort(query: any): Cursor<T>;
     skip(n: number): Cursor<T>;
     limit(n: number): Cursor<T>;
     projection(query: any): Cursor<T>;
-    exec(callback: (err: Error | null, documents: Document<T>[]) => void): void;
-    execAsync(): Promise<Document<T>>;
+    exec(callback: (err: Error | null, documents: Result extends null ? null : Result[]) => void): void;
+    execAsync(): Promise<Result>;
   }
 
   interface CursorCount {
@@ -168,8 +168,8 @@ declare namespace Nedb {
     inMemoryOnly?: boolean;
     autoload?: boolean;
     onload?(error: Error | null): any;
-    beforeDeserialization?(line: string): string|Promise<string>;
-    afterSerialization?(line: string): string|Promise<string>;
+    beforeDeserialization?(line: string): string | Promise<string>;
+    afterSerialization?(line: string): string | Promise<string>;
     corruptAlertThreshold?: number;
     compareStrings?(a: string, b: string): number;
     modes?: { fileMode: number; dirMode: number };

--- a/lib/datastore.js
+++ b/lib/datastore.js
@@ -906,9 +906,10 @@ class Datastore extends EventEmitter {
   /**
    * Find one document matching the query.
    * We return the {@link Cursor} that the user can either `await` directly or use to can {@link Cursor#skip} before.
+   * If the document is not found, `Cursor<null>` will be returned.
    * @param {query} query MongoDB-style query
    * @param {projection} projection MongoDB-style projection
-   * @return {Cursor<document>}
+   * @return {Cursor<document|null>}
    */
   findOneAsync (query, projection = {}) {
     const cursor = new Cursor(this, query, docs => docs.length === 1 ? model.deepCopy(docs[0]) : null)

--- a/typings-tests.ts
+++ b/typings-tests.ts
@@ -403,6 +403,10 @@ const db2 = new Datastore<Schema>({ filename: 'path/to/datafile' })
 db2.loadDatabase();
 
 db2.findOne({ _id: 'id1' }, (err, doc) => {
+  // @ts-expect-error
+  doc._id; //'doc' may be null there
+  doc = doc as NonNullable<typeof doc>;
+  
   doc._id; // added by nedb
   doc.hello; // provided by user
   // @ts-expect-error


### PR DESCRIPTION
If the document is not found, `Cursor<null>` will be returned