### PR TITLE
Fix object comparison

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -242,7 +242,12 @@ const compareThings = (a, b, _compareStrings) => {
     if (comp !== 0) return comp
   }
 
-  return compareNSB(aKeys.length, bKeys.length)
+  const comp = compareNSB(aKeys.length, bKeys.length)
+
+  if (comp !== 0) return comp
+
+  return compareArrays(aKeys, bKeys)
+
 }
 
 // ==============================================================

--- a/test/model.test.js
+++ b/test/model.test.js
@@ -908,6 +908,7 @@ describe('Model', function () {
       model.compareThings({}, {}).should.equal(0)
       model.compareThings({ a: 42 }, { a: 312 }).should.equal(-1)
       model.compareThings({ a: '42' }, { a: '312' }).should.equal(1)
+      model.compareThings({ a: 'v' }, { b: 'v' }).should.not.equal(0)
       model.compareThings({ a: 42, b: 312 }, { b: 312, a: 42 }).should.equal(0)
       model.compareThings({ a: 42, b: 312, c: 54 }, { b: 313, a: 42 }).should.equal(-1)
     })


### PR DESCRIPTION
Make model.compareThings actually work for objects; model.compareThings would
only check field values and object length, ignoring object keys. Now it works
for those specific cases where it would not before.


In this code:

```javascript
const db = new Datastore()
db.ensureIndex({ fieldName: "uniqueField", unique: true }, function(err) {
  db.insert({ uniqueField: { one: 'a' } }, function() {
    db.insert({ uniqueField: { another: 'a' } }, function(err) {
    })
  })
})
```

the second insert would return an error, when comparing {one:1} and {another:1},
the old function would:
1. List keys from both fields (['one'], ['another']);
2. Sort them (no change);
3. Compare the respective values ('a' and 'a')
4. Since they are all equal, compare lengths (1 and 1) and return result (legths 
are equal too).

Now, if length comparison does not return a difference, we compare the key list.
